### PR TITLE
Added the ability to select an amino acid name format after selecting the amino acid itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Standard code to access Faker
  fake.protein_name()
  # HYAL4_HUMAN
 
+ fake.amino_acid()
+ # AminoAcid(full_name='Glycine', three_letters_name='Gly', one_letter_name='G')
+ 
  fake.amino_acid_name()
  # Glycine
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Standard code to access Faker
  # HYAL4_HUMAN
 
  fake.amino_acid()
- # AminoAcid(full_name='Glycine', three_letters_name='Gly', one_letter_name='G')
+ # AminoAcid(full_name='Glycine', three_letters_name='Gly', one_letter_name='G', mass=57)
  
  fake.amino_acid_name()
  # Glycine
@@ -66,6 +66,9 @@ Standard code to access Faker
 
  fake.amino_acid_1_letter()
  # W
+
+ fake.amino_acid_mass()
+ # 103
 ```
 
 ### Molecular Biology

--- a/faker_biology/bioseq/__init__.py
+++ b/faker_biology/bioseq/__init__.py
@@ -132,7 +132,7 @@ class Bioseq(BaseProvider):
         Returns
         -------
         AminoAcid
-            A named tuple containing all variants of an amino acid name.
+            A named tuple containing all information about an amino acid.
         """
 
         return self.random_element(dna_data.amino_acids)
@@ -169,6 +169,17 @@ class Bioseq(BaseProvider):
         """
 
         return self.random_element(dna_data.amino_acids).one_letter_name
+
+    def amino_acid_mass(self) -> int:
+        """
+        A randomly chosen amino acid mass from a list of 20 amino acids
+        Returns
+        -------
+        int
+            An amino acid mass.
+        """
+
+        return self.random_element(dna_data.amino_acids).mass
 
     def _seq(self, length, alphabet):
         alphabet_length = len(alphabet) - 1

--- a/faker_biology/bioseq/__init__.py
+++ b/faker_biology/bioseq/__init__.py
@@ -126,6 +126,17 @@ class Bioseq(BaseProvider):
         key = list(dna_data.protein_names.keys())[index]
         return key, dna_data.protein_names[key]
 
+    def amino_acid(self) -> dna_data.AminoAcid:
+        """
+        A randomly chosen amino acid from a list of 20 amino acids
+        Returns
+        -------
+        AminoAcid
+            A named tuple containing all variants of an amino acid name.
+        """
+
+        return self.random_element(dna_data.amino_acids)
+
     def amino_acid_name(self) -> str:
         """
         A randomly chosen long amino acid name from a list of 20 amino acids
@@ -135,7 +146,7 @@ class Bioseq(BaseProvider):
             A long name of an amino acid.
         """
 
-        return self.random_element([item[0] for item in dna_data.amino_acids])
+        return self.random_element(dna_data.amino_acids).full_name
 
     def amino_acid_3_letters(self) -> str:
         """
@@ -146,7 +157,7 @@ class Bioseq(BaseProvider):
             A 3 letters abbreviation for amino acid name.
         """
 
-        return self.random_element([item[1] for item in dna_data.amino_acids])
+        return self.random_element(dna_data.amino_acids).three_letters_name
 
     def amino_acid_1_letter(self) -> str:
         """
@@ -157,7 +168,7 @@ class Bioseq(BaseProvider):
             A 1 letter abbreviation for amino acid name.
         """
 
-        return self.random_element([item[2] for item in dna_data.amino_acids])
+        return self.random_element(dna_data.amino_acids).one_letter_name
 
     def _seq(self, length, alphabet):
         alphabet_length = len(alphabet) - 1

--- a/faker_biology/bioseq/bioseq_data.py
+++ b/faker_biology/bioseq/bioseq_data.py
@@ -518,27 +518,27 @@ protein_names = {
 }
 
 
-AminoAcid = namedtuple('AminoAcid', ['full_name', 'three_letters_name', 'one_letter_name'])
+AminoAcid = namedtuple('AminoAcid', ['full_name', 'three_letters_name', 'one_letter_name', 'mass'])
 
 amino_acids = [
-    AminoAcid("Alanine", "Ala", "A"),
-    AminoAcid("Arginine", "Arg", "R"),
-    AminoAcid("Asparagine", "Asn", "N"),
-    AminoAcid("Aspartic Acid", "Asp", "D"),
-    AminoAcid("Cysteine", "Cys", "C"),
-    AminoAcid("Glutamic Acid", "Glu", "E"),
-    AminoAcid("Glutamine", "Gln", "Q"),
-    AminoAcid("Glycine", "Gly", "G"),
-    AminoAcid("Histidine", "His", "H"),
-    AminoAcid("Isoleucine", "Ile", "I"),
-    AminoAcid("Leucine", "Leu", "L"),
-    AminoAcid("Lysine", "Lys", "K"),
-    AminoAcid("Methionine", "Met", "M"),
-    AminoAcid("Phenylalanine", "Phe", "F"),
-    AminoAcid("Proline", "Pro", "P"),
-    AminoAcid("Serine", "Ser", "S"),
-    AminoAcid("Threonine", "Thr", "T"),
-    AminoAcid("Tryptophan", "Trp", "W"),
-    AminoAcid("Tyrosine", "Tyr", "Y"),
-    AminoAcid("Valine", "Val", "V"),
+    AminoAcid("Alanine", "Ala", "A", 71),
+    AminoAcid("Arginine", "Arg", "R", 156),
+    AminoAcid("Asparagine", "Asn", "N", 114),
+    AminoAcid("Aspartic Acid", "Asp", "D", 115),
+    AminoAcid("Cysteine", "Cys", "C", 103),
+    AminoAcid("Glutamic Acid", "Glu", "E", 129),
+    AminoAcid("Glutamine", "Gln", "Q", 128),
+    AminoAcid("Glycine", "Gly", "G", 57),
+    AminoAcid("Histidine", "His", "H", 137),
+    AminoAcid("Isoleucine", "Ile", "I", 113),
+    AminoAcid("Leucine", "Leu", "L", 113),
+    AminoAcid("Lysine", "Lys", "K", 128),
+    AminoAcid("Methionine", "Met", "M", 131),
+    AminoAcid("Phenylalanine", "Phe", "F", 147),
+    AminoAcid("Proline", "Pro", "P", 97),
+    AminoAcid("Serine", "Ser", "S", 87),
+    AminoAcid("Threonine", "Thr", "T", 101),
+    AminoAcid("Tryptophan", "Trp", "W", 186),
+    AminoAcid("Tyrosine", "Tyr", "Y", 163),
+    AminoAcid("Valine", "Val", "V", 99),
 ]

--- a/faker_biology/bioseq/bioseq_data.py
+++ b/faker_biology/bioseq/bioseq_data.py
@@ -5,6 +5,8 @@ Created on Sun Feb 13 10:20:19 2022
 
 @author: richard
 """
+from collections import namedtuple
+
 ambiguous_dna_letters = "GATCRYWSMKHBVDN"
 unambiguous_dna_letters = "GATC"
 ambiguous_rna_letters = "GAUCRYWSMKHBVDN"
@@ -516,25 +518,27 @@ protein_names = {
 }
 
 
+AminoAcid = namedtuple('AminoAcid', ['full_name', 'three_letters_name', 'one_letter_name'])
+
 amino_acids = [
-    ("Alanine", "Ala", "A"),
-    ("Arginine", "Arg", "R"),
-    ("Asparagine", "Asn", "N"),
-    ("Aspartic Acid", "Asp", "D"),
-    ("Cysteine", "Cys", "C"),
-    ("Glutamic Acid", "Glu", "E"),
-    ("Glutamine", "Gln", "Q"),
-    ("Glycine", "Gly", "G"),
-    ("Histidine", "His", "H"),
-    ("Isoleucine", "Ile", "I"),
-    ("Leucine", "Leu", "L"),
-    ("Lysine", "Lys", "K"),
-    ("Methionine", "Met", "M"),
-    ("Phenylalanine", "Phe", "F"),
-    ("Proline", "Pro", "P"),
-    ("Serine", "Ser", "S"),
-    ("Threonine", "Thr", "T"),
-    ("Tryptophan", "Trp", "W"),
-    ("Tyrosine", "Tyr", "Y"),
-    ("Valine", "Val", "V"),
+    AminoAcid("Alanine", "Ala", "A"),
+    AminoAcid("Arginine", "Arg", "R"),
+    AminoAcid("Asparagine", "Asn", "N"),
+    AminoAcid("Aspartic Acid", "Asp", "D"),
+    AminoAcid("Cysteine", "Cys", "C"),
+    AminoAcid("Glutamic Acid", "Glu", "E"),
+    AminoAcid("Glutamine", "Gln", "Q"),
+    AminoAcid("Glycine", "Gly", "G"),
+    AminoAcid("Histidine", "His", "H"),
+    AminoAcid("Isoleucine", "Ile", "I"),
+    AminoAcid("Leucine", "Leu", "L"),
+    AminoAcid("Lysine", "Lys", "K"),
+    AminoAcid("Methionine", "Met", "M"),
+    AminoAcid("Phenylalanine", "Phe", "F"),
+    AminoAcid("Proline", "Pro", "P"),
+    AminoAcid("Serine", "Ser", "S"),
+    AminoAcid("Threonine", "Thr", "T"),
+    AminoAcid("Tryptophan", "Trp", "W"),
+    AminoAcid("Tyrosine", "Tyr", "Y"),
+    AminoAcid("Valine", "Val", "V"),
 ]

--- a/faker_biology/tests/test_bioseq.py
+++ b/faker_biology/tests/test_bioseq.py
@@ -102,3 +102,8 @@ class BioseqTest(unittest.TestCase):
     def test_amino_acid(self):
         amino_acid = fake.amino_acid()
         self.assertIn(amino_acid, bioseq_data.amino_acids)
+
+    def test_amino_mass(self):
+        masses = [71, 156, 114, 115, 103, 129, 128, 57, 137, 113, 113, 128, 131, 147, 97, 87, 101, 186, 163, 99]
+        amino_acid_mass = fake.amino_acid_mass()
+        self.assertIn(amino_acid_mass, masses)

--- a/faker_biology/tests/test_bioseq.py
+++ b/faker_biology/tests/test_bioseq.py
@@ -98,3 +98,7 @@ class BioseqTest(unittest.TestCase):
 
         amino_acid = fake.amino_acid_1_letter()
         self.assertIn(amino_acid, amino_acid_names)
+
+    def test_amino_acid(self):
+        amino_acid = fake.amino_acid()
+        self.assertIn(amino_acid, bioseq_data.amino_acids)


### PR DESCRIPTION
I have a case, when the same amino acid is used in two DB fields in one- and three- letters formats.