### PR TITLE
[fix] Sequence generator uses Faker's random seed.

### DIFF
--- a/faker_biology/bioseq/__init__.py
+++ b/faker_biology/bioseq/__init__.py
@@ -185,6 +185,6 @@ class Bioseq(BaseProvider):
         alphabet_length = len(alphabet) - 1
         seq = []
         for i in range(length):
-            j = random.randint(0, alphabet_length)
+            j = self.generator.random.randint(0, alphabet_length)
             seq.append(alphabet[j])
         return "".join(seq)


### PR DESCRIPTION
Fixes richarda23/faker-biology#6

Update sequence generator to use faker's random seed.

After this change, generated sequences are consistent for a given seed:
```
# for i in [1 ... 3]; do python3 scripts/repro_bioseq.py; done;
Authors:
1 / Sylvia Young / TAGGGGGAACTTCCGCAATAGTCCCACAAGCGTCGCACGACTGGCAGAGATGGCGCAGAATCGTCCCCGCTCTGAATGGAGGTCATTCATAGGAGCGCAA
Authors:
1 / Sylvia Young / TAGGGGGAACTTCCGCAATAGTCCCACAAGCGTCGCACGACTGGCAGAGATGGCGCAGAATCGTCCCCGCTCTGAATGGAGGTCATTCATAGGAGCGCAA
Authors:
1 / Sylvia Young / TAGGGGGAACTTCCGCAATAGTCCCACAAGCGTCGCACGACTGGCAGAGATGGCGCAGAATCGTCCCCGCTCTGAATGGAGGTCATTCATAGGAGCGCAA
```