### PR TITLE
Release 0.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,18 @@ All significant changes to the project will be recorded here.
 
 ## Unreleased
 
+## 0.6.7 2026-03-08
+
 ### Breaking change
 
 - fake.organism() renamed to fake.organism_english() so that fake.organism() can return a named tuple.
+
+### Fixed
+
+- Add missing return type hints across providers
+- Fix taxonomy tests and bump minimum Python version to 3.9
+- Lazy-load restriction enzyme data to avoid eager 437KB import on unrelated provider use
+- Fix deprecated `[tool.poetry.dev-dependencies]` syntax and regenerate lock file
 
 ## 0.6.6 2026-03-08
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "faker-biology"
 
-version = "0.6.6"
+version = "0.6.7"
 description = "Fake data from biology"
 authors = ["Richard Adams <ra22597@gmail.com>"]
 license = "Apache 2"


### PR DESCRIPTION
## Summary

- Move Unreleased items into 0.6.7 changelog section
- Include changes from PRs #28 and #30 (type hints, lazy-load RE data, poetry fix)
- Bump version to 0.6.7 in pyproject.toml
- Run `poetry update` (faker 35.2.2 → 37.12.0, pluggy, typing-extensions updated)

## Test plan

- [ ] Full suite: `poetry run python -m pytest faker_biology/tests/` — 35 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)